### PR TITLE
Added related-video component

### DIFF
--- a/src/components/RelatedVideo.jsx
+++ b/src/components/RelatedVideo.jsx
@@ -13,7 +13,7 @@ export default class RelatedVideo extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const params = {
       maxResults: '10',
       part: 'snippet',

--- a/src/components/RelatedVideo.jsx
+++ b/src/components/RelatedVideo.jsx
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import YoutubeApi from '../modules/YoutubeApi';
+
+export default class RelatedVideo extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      result: [],
+    };
+  }
+
+  componentWillMount() {
+    const params = {
+      maxResults: '10',
+      part: 'snippet',
+      relatedToVideoId: this.props.videoId,
+      type: 'video',
+    };
+    const ya = new YoutubeApi('search', params);
+    ya.call().then(result => {
+      console.log(result);
+    }).catch(error => {
+      console.log(error);
+    });
+  }
+
+  render() {
+    return (
+      <div>
+      </div>
+    );
+  }
+}

--- a/src/components/RelatedVideo.jsx
+++ b/src/components/RelatedVideo.jsx
@@ -1,11 +1,15 @@
 import React, { Component } from 'react';
+import GridList from '@material-ui/core/GridList';
+import GridListTile from '@material-ui/core/GridListTile';
+import GridListTileBar from '@material-ui/core/GridListTileBar';
+import ListSubheader from '@material-ui/core/ListSubheader';
 import YoutubeApi from '../modules/YoutubeApi';
 
 export default class RelatedVideo extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      result: [],
+      items: [],
     };
   }
 
@@ -18,15 +22,30 @@ export default class RelatedVideo extends Component {
     };
     const ya = new YoutubeApi('search', params);
     ya.call().then(result => {
-      console.log(result);
+      this.setState({items: result['data']['items']});
     }).catch(error => {
       console.log(error);
     });
   }
 
   render() {
+    console.log(this.state.items);
     return (
       <div>
+        <GridList cellHeight={180} cols={1} style={{ width: '320px' }}>
+          <GridListTile key="Subheader" cols={1} style={{ height: 'auto' }}>
+            <ListSubheader component="div">December</ListSubheader>
+          </GridListTile>
+          {this.state.items.map(item => (
+            <GridListTile key={item.snippet.title}>
+              <img src={item.snippet.thumbnails.medium.url} alt={item.snippet.title} />
+              <GridListTileBar
+                title={item.snippet.title}
+                subtitle={item.snippet.channelTitle}
+              />
+            </GridListTile>
+          ))}
+        </GridList>
       </div>
     );
   }

--- a/src/components/RelatedVideo.jsx
+++ b/src/components/RelatedVideo.jsx
@@ -29,7 +29,6 @@ export default class RelatedVideo extends Component {
   }
 
   render() {
-    console.log(this.state.items);
     return (
       <div>
         <GridList cellHeight={180} cols={1} style={{ width: '320px' }}>


### PR DESCRIPTION
I used a grid list pf material-ui and displayed related videos. 
https://material-ui.com/demos/grid-list/

Anchor links haven't been valid yet. I will implement it after adding react-router.
In case of test, like this pr #12 , I added code as below.
* App.js
```js
import { Grid } from '@material-ui/core';
import RelatedVideo from './components/RelatedVideo';    // added
dotenv.config();
...
           <Grid item xs={6}>
              <SearchBar />
              <RelatedVideo videoId="2g811Eo7K8U"/>    // added
            </Grid>
```