### PR TITLE
Fix the way of main component grid separating

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,21 +11,9 @@ class App extends Component {
     return (
       <div>
         <NavBar />
-        <Grid container alignItems="center" style={{height:'600px'}}>
-          <Grid 
-            container 
-            justify="center" 
-            alignItems="center"
-            spacing={8}
-            style={{textAlign: 'center'}}
-          >
-
-            <Grid item xs={8}>
-              <h1>This is a Youtube Clone site and is under development.</h1>
-            </Grid>
-            <Grid item xs={6}>
-              <Main /> {/* Main component holding all the routes */}
-            </Grid>
+        <Grid container justify="center" alignItems="center" style={{marginTop: '30px'}}>
+          <Grid item xs={8}>
+            <Main /> {/* Main component holding all the routes */}
           </Grid>
         </Grid>
       </div>

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -3,15 +3,20 @@ import { Input, Button, Grid, Typography } from '@material-ui/core';
 import YoutubeApi from '../modules/YoutubeApi';
 
 export default class SearchBar extends Component {
-  state = { value: '' };
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: '',
+    };
+  }
 
   onFormSubmit(event) {
     event.preventDefault();
     const params = {
-        maxResults: '20',
-        part: 'snippet',
-        q: this.state.value,
-        type: 'video, playlist',
+      maxResults: '20',
+      part: 'snippet',
+      q: this.state.value,
+      type: 'video, playlist',
     };
     const ya = new YoutubeApi('search', params);
     ya.call().then(result => {
@@ -24,16 +29,29 @@ export default class SearchBar extends Component {
   }
 
   render() {
-    const { buttonStyle } = styles;
+    const styles = {
+      container: {
+        marginTop: '150px',
+      },
+      form: {
+        marginTop: '30px',
+        textAlign: 'center', 
+      },
+      buttonStyle: {
+        marginTop: '10px',
+        backgroundColor: '#2196f3', 
+        color: '#fff',
+      },
+    };
 
     return (
       <div>
-        <Grid container justify="center" alignItems="center" style={{marginTop: '200px', textAlign: 'center'}}>
+        <Grid container justify="center" alignItems="center" style={styles.container}>
           <Grid item xs={8}>
-            <Typography align="center" variant="headline">
+            <Typography align="center" variant="display1">
               This is a Youtube Clone site and is under development.
             </Typography>
-            <form onSubmit={this.onFormSubmit.bind(this)}>
+            <form onSubmit={this.onFormSubmit.bind(this)} style={styles.form}>
               <Input 
                 placeholder="Search" 
                 fullWidth 
@@ -45,7 +63,7 @@ export default class SearchBar extends Component {
               <Button 
                 type="submit"
                 variant="contained"
-                style={buttonStyle} 
+                style={styles.buttonStyle}
               >
               Search
               </Button>
@@ -56,11 +74,3 @@ export default class SearchBar extends Component {
     );
   }
 }
-
-const styles = {
-  buttonStyle: {
-    marginTop: '10px',
-    backgroundColor: '#2196f3', 
-    color: '#fff'
-  }
-};

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Input, Button } from '@material-ui/core';
+import { Input, Button, Grid, Typography } from '@material-ui/core';
 import YoutubeApi from '../modules/YoutubeApi';
 
 export default class SearchBar extends Component {
@@ -28,23 +28,30 @@ export default class SearchBar extends Component {
 
     return (
       <div>
-        <form onSubmit={this.onFormSubmit.bind(this)}>
-          <Input 
-            placeholder="Search" 
-            fullWidth 
-            style={{paddingLeft: '3px'}}
-            type="search" 
-            onChange={event => this.setState({ value: event.target.value })}
-            value={this.state.value}
-          />
-          <Button 
-            type="submit"
-            variant="contained"
-            style={buttonStyle} 
-          >
-          Search
-          </Button>
-        </form>
+        <Grid container justify="center" alignItems="center" style={{marginTop: '200px', textAlign: 'center'}}>
+          <Grid item xs={8}>
+            <Typography align="center" variant="headline">
+              This is a Youtube Clone site and is under development.
+            </Typography>
+            <form onSubmit={this.onFormSubmit.bind(this)}>
+              <Input 
+                placeholder="Search" 
+                fullWidth 
+                style={{paddingLeft: '3px'}}
+                type="search" 
+                onChange={event => this.setState({ value: event.target.value })}
+                value={this.state.value}
+              />
+              <Button 
+                type="submit"
+                variant="contained"
+                style={buttonStyle} 
+              >
+              Search
+              </Button>
+            </form>
+          </Grid>
+        </Grid>
       </div>
     );
   }


### PR DESCRIPTION
This pr is the preparation before getting watch page. I submited this pr because of avoiding big pr.

In case of current grid separating, when VideoViewer and RelatedVideo is arranged in line, the layout is broken.
for that reason, I fixed as below. looks has changed a little.
- changed xs prop value
- changed the way of grid separating
- adjusted css
  - style attribute might not be recommended. I created trello task about this point.
- changed to show the folloiwng sentence in only top page.
`This is a Youtube Clone site and is under development.`
  - if any problems, please point out.
- move state initialization in SearchBar (refactoring fix)
